### PR TITLE
Create CODEOWNERS and automate reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+posts/ @esds-core
+*.md @esds-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-posts/ @esds-core
-*.md @esds-core
+posts/ @NCAR/esds-core
+*.md @NCAR/esds-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 posts/ @NCAR/esds-core
 *.md @NCAR/esds-core
+*.py @NCAR/esds-infrastructure
+*.yaml @NCAR/esds-infrastructure
+.github/ @NCAR/esds-infrastructure


### PR DESCRIPTION
I've created an @NCAR/esds-core team that can be automatically requested for review on certain pages because of being listed in the CODEOWNERS file.

Do we want to subdivide this more into an infrastructure and content team? 

And those teams own certain files -  for people who feel comfortable proofreading blog posts, but not commenting on changes to how the site works (I imagine most PRs are content related at this point).