### PR TITLE
Added AWSIG

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -76,6 +76,9 @@ lab attend as well.
 
 ### Want to suggest a topic for the AWSIG?
 
+If you'd like to propose a discussion topic, or upvote a suggested topic,
+please use the spreadsheet [here](https://docs.google.com/spreadsheets/d/14BT79YxmWOHFVm1kV8TDYMGQvNPjKZvQwq2OHx9zXGY/edit?usp=sharing)
+
 
 
 ## [Office Hours](https://docs.google.com/document/d/1gIK0C-srceYmoYtgoODeLtuPQPL40iAHoI9DXWqfWP0/edit?usp=sharing)

--- a/communication.md
+++ b/communication.md
@@ -35,6 +35,49 @@ Every other Monday from 2-3pm MT via Zoom, we hold the ESDS Forum, which provide
 
 If you are interested in giving a talk or leading a discussion, please fill out this [ESDS Forum sign-up spreadsheet](https://docs.google.com/spreadsheets/d/1Tuv5vwGbjSKdJD5KLT0Zow8WCY0_zt35tTI6EIRGOk4/edit?usp=sharing). See the [ESDS Forum Meeting Notes](https://docs.google.com/document/d/e/2PACX-1vQeHIGSSz_8A8gZVL87xDjYXEwqB4CkRk85yf0TACb-rVgubjb3ukiulEYuUwHZGVXhgYNpaRC2SNAt/pub) for an overview of previous discussions.
 
+## Analysis Workflow Special Interest Group (AWSIG)
+
+The AWSIG provides a communication forum for the exchange of ideas
+and experiences related to the operational aspects of CISL supported
+**analysis** resources and services (e.g. Casper,  JupyterHub,
+GLADE, VirtualGL, etc.). This working group complements the more
+modeling/simulation focused [NCAR HPC User Group
+(NHUG)](https://arc.ucar.edu/knowledge_base/70549847).
+
+The AWSIG Seeks to:
+
+- Connect the users & providers of CISL’s analysis resources at regular intervals,
+- Provide advice and feedback to CISL on the current state and future delivery of CISL analysis resources and services, 
+- Promote the effective use of NCAR computing facilities by sharing experiences,
+- Collaborate to enhance productivity when using CISL resources,
+- Suggest new research and technology directions in scientific computing,
+- Voice user concerns.
+
+### Organization
+
+The AWSIG will hold ~bi-monthly meetings during the ESDS Forum. The
+CISL consulting group (CSG) will coordinate meetings with assistance
+as needed from the ESDS leadership. Meetings will consist of free
+format discussions, and informational presentations from CISL
+technical staff and NCAR/UCAR scientific staff.
+
+CSG will rely on both ESDS leadership and the community to propose
+topics of interest, and even to present emerging tools, best
+practices, etc. A successful SIG will be driven by interested
+stakeholders, as well as from the resource providers in CISL. CSG
+will have items to directly contribute, but also do a lot of listening
+and then implementing feedback.
+
+### Membership & Participation
+The AWSIG is open to all users of NCAR’s HPC resources. Representatives
+from CISL’s Consulting Group and relevant resource providers will
+be in attendance. We desire that representatives from each scientific
+lab attend as well.
+
+### Want to suggest a topic for the AWSIG?
+
+
+
 ## [Office Hours](https://docs.google.com/document/d/1gIK0C-srceYmoYtgoODeLtuPQPL40iAHoI9DXWqfWP0/edit?usp=sharing)
 
 Have a question about Python/data analysis issues? Looking to get feedback on some project? Stop by our office hours! You do NOT need to have submitted a question in advance.


### PR DESCRIPTION
This PR adds information about the AWSIG. 

I put the content under the Communications section. Not sure that this is the best place for it, but I think it will do for now. 