### PR TITLE
Office Hours site now on Sundog

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -87,6 +87,9 @@ Have a question about Python/data analysis issues? Looking to get feedback on so
 Several ESDS members are prepared to answer your Python questions via 1-on-1 appointments. You can now select the ESDS member with the specialization best equiped for your question, find a time that works for you, and generate an appointment. Please also provide how you'd like to meet (in-person or virtual) and a brief description of your question.
 
 If your question is about an error message you are raising in your workflow, help us help you by being ready to provide a copy of your dataset and code so we can reproduce your error. Depending on your question, we may be able to walk you through a solution or send you documentation/resources that address your question. See the [Office Hour Notes](https://docs.google.com/document/d/1gIK0C-srceYmoYtgoODeLtuPQPL40iAHoI9DXWqfWP0/edit?usp=sharing) for a summary of previous sessions.
+ 
+**NOTE:** Office hours are open to NCAR/UCAR staff only.
+
 
 ## [Project Pythia](https://projectpythia.org/)
 

--- a/communication.md
+++ b/communication.md
@@ -87,9 +87,8 @@ Have a question about Python/data analysis issues? Looking to get feedback on so
 Several ESDS members are prepared to answer your Python questions via 1-on-1 appointments. You can now select the ESDS member with the specialization best equiped for your question, find a time that works for you, and generate an appointment. Please also provide how you'd like to meet (in-person or virtual) and a brief description of your question.
 
 If your question is about an error message you are raising in your workflow, help us help you by being ready to provide a copy of your dataset and code so we can reproduce your error. Depending on your question, we may be able to walk you through a solution or send you documentation/resources that address your question. See the [Office Hour Notes](https://docs.google.com/document/d/1gIK0C-srceYmoYtgoODeLtuPQPL40iAHoI9DXWqfWP0/edit?usp=sharing) for a summary of previous sessions.
- 
-**NOTE:** Office hours are open to NCAR/UCAR staff only.
 
+**NOTE:** Office hours are open to NCAR/UCAR staff only.
 
 ## [Project Pythia](https://projectpythia.org/)
 

--- a/office-hours.md
+++ b/office-hours.md
@@ -1,13 +1,1 @@
-# Office Hours
-
-<iframe
-  src="https://app.squarespacescheduling.com/schedule.php?owner=26907589&appointmentType=35983319"
-  title="Schedule Appointment"
-  width="100%"
-  height="800"
-  frameborder="0"
-></iframe>
-<script
-  src="https://embed.acuityscheduling.com/js/embed.js"
-  type="text/javascript"
-></script>
+<meta http-equiv="Refresh" content="0; url='[https://www.w3docs.com](https://sundog.ucar.edu/Interact/Pages/Content/Document.aspx?id=6160)'" />

--- a/office-hours.md
+++ b/office-hours.md
@@ -1,1 +1,11 @@
-<meta http-equiv="Refresh" content="0; url='[https://www.w3docs.com](https://sundog.ucar.edu/Interact/Pages/Content/Document.aspx?id=6160)'" />
+# Office Hours
+
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="refresh" content="7; url='https://www.w3docs.com'" />
+  </head>
+  <body>
+    <p>Please follow this link to the <a href="https://sundog.ucar.edu/Interact/Pages/Content/Document.aspx?id=6160">Sundog UCAR Portal office hours page. </a>.</p>
+  </body>
+</html>


### PR DESCRIPTION
This PR redirects the office hours site to the sundog site. This is so that the office hours are behind a Duo push as requested by the Security team.

Closes #195 