### PR TITLE
unlock office hours (make available outside of Sundog)

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -88,7 +88,7 @@ Several ESDS members are prepared to answer your Python questions via 1-on-1 app
 
 If your question is about an error message you are raising in your workflow, help us help you by being ready to provide a copy of your dataset and code so we can reproduce your error. Depending on your question, we may be able to walk you through a solution or send you documentation/resources that address your question. See the [Office Hour Notes](https://docs.google.com/document/d/1gIK0C-srceYmoYtgoODeLtuPQPL40iAHoI9DXWqfWP0/edit?usp=sharing) for a summary of previous sessions.
 
-**NOTE:** Office hours are open to NCAR/UCAR staff only.
+**NOTE:** Office hours are designed for NCAR/UCAR staff.
 
 ## [Project Pythia](https://projectpythia.org/)
 

--- a/office-hours.md
+++ b/office-hours.md
@@ -1,11 +1,13 @@
 # Office Hours
 
-<!DOCTYPE html>
-<html>
-  <head>
-    <meta http-equiv="refresh" content="7; url='https://www.w3docs.com'" />
-  </head>
-  <body>
-    <p>Please follow this link to the <a href="https://sundog.ucar.edu/Interact/Pages/Content/Document.aspx?id=6160">Sundog UCAR Portal office hours page. </a>.</p>
-  </body>
-</html>
+<iframe
+  src="https://app.squarespacescheduling.com/schedule.php?owner=26907589&appointmentType=35983319"
+  title="Schedule Appointment"
+  width="100%"
+  height="800"
+  frameborder="0"
+></iframe>
+<script
+  src="https://embed.acuityscheduling.com/js/embed.js"
+  type="text/javascript"
+></script>


### PR DESCRIPTION
There were some good reasons to not hide office hours behind sundog, and attendance has gone down since this change (perhaps the barrier is too inconvenient?) so this PR undoes that.