### PR TITLE
Change forum description to hybrid meeting

### DIFF
--- a/communication.md
+++ b/communication.md
@@ -25,7 +25,7 @@ This repository and webpage is a space where we can post progress on this initia
 
 ## [ESDS Forum](https://docs.google.com/document/d/e/2PACX-1vQeHIGSSz_8A8gZVL87xDjYXEwqB4CkRk85yf0TACb-rVgubjb3ukiulEYuUwHZGVXhgYNpaRC2SNAt/pub)
 
-Every other Monday from 2-3pm MT via Zoom, we hold the ESDS Forum, which provides a venue for discussion, coordination and showcasing work in progress. Examples include:
+Every other Monday from 2-3pm MT, we hold the ESDS Forum in person and over Google Meet, which provides a venue for discussion, coordination and showcasing work in progress. Examples include:
 
 - Workflow demos
 - Overview of packages and analysis tools


### PR DESCRIPTION
Now that the ESDS Forum is in a hybrid format, we need to update the communications page accordingly.