### PR TITLE
Bump version of isort to 5.12.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
A pre-commit error is coming up in another PR. This is a bug due to an out-of-date version of the `isort` pre-commit hook. This PR bumps the version of `isort` to it's latest version.