### PR TITLE
Remove duplicated search bars

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -64,9 +64,8 @@ html_theme = 'pydata_sphinx_theme'
 # Add some more theme Options
 html_theme_options = {
     'github_url': 'https://github.com/ncar/esds',
-    'search_bar_text': 'Search this site... ',
     'google_analytics_id': 'UA-196809533-1',
-    'navbar_end': ['search-field.html', 'navbar-icon-links'],
+    'navbar_end': ['navbar-icon-links'],
 }
 
 rediraffe_redirects = 'redirects.txt'
@@ -82,15 +81,13 @@ html_sidebars = {
     'about': ['hello.html'],
     'faq': ['hello.html'],
     'communication': ['hello.html'],
-    'blog': ['search-field.html', 'sidebar-nav-bs.html', 'tagcloud.html', 'archives.html'],
+    'blog': ['sidebar-nav-bs.html', 'tagcloud.html', 'archives.html'],
     'posts/**': [
-        'search-field.html',
         'sidebar-nav-bs.html',
         'postcard.html',
         'recentposts.html',
         'archives.html',
     ],
-    #    "**": ["search-field.html", "sidebar-nav-bs.html"]
 }
 
 


### PR DESCRIPTION
This just cleans up the duplicated search bars on the site and leaves only the default search button.  

We could handle this by removing the search button and choosing a persistent location for the search bar as well, but this seemed simpler and it's [recommended not to have both](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/search.html).



