### PR TITLE
Remove blog comments

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,7 +33,6 @@ release = '0.1'
 extensions = [
     'myst_nb',
     'ablog',
-    'sphinx_comments',
     'sphinxext.rediraffe',
     'sphinx_design',
     'sphinx_copybutton',
@@ -110,11 +109,6 @@ myst_url_schemes = ['http', 'https', 'mailto']
 
 # Temporarily stored as off until we fix it
 jupyter_execute_notebooks = 'off'
-
-
-comments_config = {
-    'utterances': {'repo': 'NCAR/esds', 'optional': 'config', 'label': '💬 comment'},
-}
 
 
 def setup(app):


### PR DESCRIPTION
Removes the comments sections (e.g. for blog posts).

This is perhaps worth some discussion, but given the level of use and attention comments get it seemed like it might be worth tidying this up.  

It seems like discussion tends to happen in other locations e.g. Zulip, issues, etc. and that seems probably better anyway.