### PR TITLE
Add explicit Sphinx configuration to the ReadTheDocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,6 @@
 version: 2
+sphinx:
+  configuration: conf.py
 conda:
   environment: environment.yml
 build:


### PR DESCRIPTION
Adds explicit Sphinx configuration to the ReadTheDocs configuration file per the guidance here: https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

This should hopefully fix the docs build issue that @TeaganKing was seeing in her PR.

