### PR TITLE
Updates GitHub Actions workflows per new guidance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
       # Install dependencies
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@505e6394dae86d6a5c7fbb6e3fb8938e3e863830 #v3.1.1
         with:
           environment-file: environment.yml
           activate-environment: esds-blog
@@ -31,7 +31,7 @@ jobs:
           make dirhtml
       # Push the book's HTML to github-pages
       - name: GitHub Pages action
-        uses: peaceiris/actions-gh-pages@v4.0.0
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e #v4.0.0
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Updates GitHub Actions workflows to pin third party actions to commit hashes rather than version tags.

This should hopefully cover the changes needed in the repository code and should still work with Dependabot updates though we'll need to make sure we review any changes in the source code when those updates are proposed by Dependabot.

Closes #309