### PR TITLE
Formatting updates and general clean up

### DIFF
--- a/_templates/hello.html
+++ b/_templates/hello.html
@@ -1,11 +1,10 @@
 <div class="bio-info">
-  <div class="name">Earth System Data Science initiative at NSF NCAR</div>
+  <div class="name">Earth System Data Science (ESDS) at NSF NCAR & UCAR</div>
 
   <div class="whatido">
     <p>Building an inclusive sociotechnical network to promote effective synthesis
     and interpretation of data relevant to solving problems in Earth system
     science and supporting decisions within stakeholder communities.</p>
 
-    <p>The Earth System Data Science initiative follows these <a href="https://www.ucar.edu/accessibility">accsesibility guidelines</a></p>
   </div>
 </div>

--- a/about.md
+++ b/about.md
@@ -1,4 +1,4 @@
-# About Us
+# About
 
 The Earth System Data Science (ESDS) initiative is a community
 with a common interest in advancing geoscientist’s ability to make
@@ -27,7 +27,7 @@ described in our [governance document](https://docs.google.com/document/d/1xjNzJ
 
 ## Vision
 
-_The Earth System Data Science initiative aims to profoundly increase the effectiveness of the NSF NCAR and UCAR workforce by promoting deeper collaboration centered on analytics, improving our capacity to deliver impactful, actionable, reproducible science and serve the university community by transforming how geoscientists synthesize and extract information from large, diverse data sets._
+The Earth System Data Science initiative aims to profoundly increase the effectiveness of the NSF NCAR and UCAR workforce by promoting deeper collaboration centered on analytics, improving our capacity to deliver impactful, actionable, reproducible science and serve the university community by transforming how geoscientists synthesize and extract information from large, diverse data sets._
 
 Effective synthesis and analysis of large datasets is a rate-limiting step to advancing science across NSF NCAR and UCAR and our community. Recent developments in open-source scientific software, notably those identified by the [Pangeo community](https://pangeo.io/), provide both inspiring technical solutions to Big Data geoscience problems and paradigms for large-scale collaboration. Analysis workflows across NSF NCAR and UCAR share much in common, despite disciplinary differences; thus, a focus on data and its transformation into useful information illuminates the potential for novel collaborations across the organization. Moreover, open, collaborative development focused on reproducible science holds transformative potential for how NSF NCAR and UCAR and the community approaches science.
 

--- a/communication.md
+++ b/communication.md
@@ -1,4 +1,4 @@
-# Communication and Meetings
+# Community
 
 ## Email List
 

--- a/communication.md
+++ b/communication.md
@@ -49,7 +49,7 @@ Slack is an asynchronous messaging platform which can be used for both private m
 
 ## ESDS Forum
 
-Every other Monday from 2-3pm MT, we hold the ESDS Forum over [Google Meet](meet.google.com/mfb-whpi-tnj), which provides a venue for discussion, coordination and showcasing work in progress. Examples include:
+Every other Monday from 2-3pm MT, we hold the ESDS Forum over [Google Meet](https://meet.google.com/mfb-whpi-tnj), which provides a venue for discussion, coordination and showcasing work in progress. Examples include:
 
 - Workflow demos
 - Overview of packages and analysis tools

--- a/conf.py
+++ b/conf.py
@@ -72,6 +72,7 @@ html_theme = 'pydata_sphinx_theme'
 
 # Add some more theme Options
 html_theme_options = {
+    'github_url': 'https://github.com/NCAR/esds'
     'navbar_end': ['search-button', 'theme-switcher', 'navbar-icon-links'],
     'navbar_persistent': [],
     'icon_links': [

--- a/conf.py
+++ b/conf.py
@@ -72,9 +72,8 @@ html_theme = 'pydata_sphinx_theme'
 
 # Add some more theme Options
 html_theme_options = {
-    'github_url': 'https://github.com/NCAR/esds'
-    'navbar_end': ['search-button', 'theme-switcher', 'navbar-icon-links'],
-    'navbar_persistent': [],
+    'github_url': 'https://github.com/NCAR/esds',
+    'navbar_end': ['theme-switcher', 'navbar-icon-links'],
     'icon_links': [
         {
             "name": "YouTube",
@@ -101,13 +100,8 @@ html_sidebars = {
     'index': ['hello.html'],
     'about': ['hello.html'],
     'communication': ['hello.html'],
-    'blog': ['sidebar-nav-bs.html', 'tagcloud.html', 'archives.html'],
-    'posts/**': [
-        'sidebar-nav-bs.html',
-        'postcard.html',
-        'recentposts.html',
-        'archives.html',
-    ],
+    'blog': ['ablog/recentposts.html', 'ablog/archives.html', 'ablog/tagcloud.html'],
+    'posts/**': ['ablog/postcard.html', 'ablog/recentposts.html', 'ablog/archives.html'],
 }
 
 
@@ -127,10 +121,8 @@ panels_add_bootstrap_css = False
 myst_enable_extensions = ['amsmath', 'colon_fence', 'deflist', 'html_image', 'dollarmath']
 myst_url_schemes = ['http', 'https', 'mailto']
 
-
 # Temporarily stored as off until we fix it
-jupyter_execute_notebooks = 'off'
-
+nb_execution_mode = 'off'
 
 # def setup(app):
 #     app.add_css_file('custom.css')

--- a/conf.py
+++ b/conf.py
@@ -72,8 +72,6 @@ html_theme = 'pydata_sphinx_theme'
 
 # Add some more theme Options
 html_theme_options = {
-    'github_url': 'https://github.com/ncar/esds',
-    'google_analytics_id': 'UA-196809533-1',
     'navbar_end': ['search-button', 'theme-switcher', 'navbar-icon-links'],
     'navbar_persistent': [],
     'icon_links': [
@@ -84,6 +82,10 @@ html_theme_options = {
             "type": "fontawesome",
         },
     ],
+}
+
+html_theme_options["analytics"] = {
+    "google_analytics_id": "UA-196809533-1",
 }
 
 rediraffe_redirects = 'redirects.txt'

--- a/conf.py
+++ b/conf.py
@@ -68,10 +68,15 @@ html_context = {
     "doc_path": "",
 }
 
+html_static_path = ["_static"]
+html_css_files = ["custom.css"]
+html_show_sourcelink = False
+
 html_theme = 'pydata_sphinx_theme'
 
 # Add some more theme Options
 html_theme_options = {
+    'use_edit_page_button': True,
     'github_url': 'https://github.com/NCAR/esds',
     'navbar_end': ['theme-switcher', 'navbar-icon-links'],
     'icon_links': [
@@ -100,6 +105,8 @@ html_sidebars = {
     'index': ['hello.html'],
     'about': ['hello.html'],
     'communication': ['hello.html'],
+    'office-hours': ['hello.html'],
+    'resources': ['hello.html'],
     'blog': ['ablog/recentposts.html', 'ablog/archives.html', 'ablog/tagcloud.html'],
     'posts/**': ['ablog/postcard.html', 'ablog/recentposts.html', 'ablog/archives.html'],
 }
@@ -124,5 +131,3 @@ myst_url_schemes = ['http', 'https', 'mailto']
 # Temporarily stored as off until we fix it
 nb_execution_mode = 'off'
 
-# def setup(app):
-#     app.add_css_file('custom.css')

--- a/conf.py
+++ b/conf.py
@@ -17,9 +17,9 @@
 
 # -- Project information -----------------------------------------------------
 
-project = 'ESDS'
-copyright = '2024'
-author = 'Earth System Data Science (ESDS) community'
+project = 'ESDS Website'
+copyright = '2024, ESDS Community'
+author = 'ESDS Community'
 
 
 # -- General configuration ---------------------------------------------------
@@ -57,6 +57,16 @@ language = 'en'
 #
 
 html_logo = "_static/esds_logo.png"
+html_favicon = "_static/esds_logo.png"
+html_sourcelink_suffix = ""
+html_last_updated_fmt = ""
+
+html_context = {
+    "github_user": "NCAR",
+    "github_repo": "esds",
+    "github_version": "main",
+    "doc_path": "",
+}
 
 html_theme = 'pydata_sphinx_theme'
 

--- a/conf.py
+++ b/conf.py
@@ -18,7 +18,7 @@
 # -- Project information -----------------------------------------------------
 
 project = 'ESDS Website'
-copyright = '2024, ESDS Community'
+copyright = '2021, ESDS Community'
 author = 'ESDS Community'
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,10 +17,8 @@ dependencies:
   - matplotlib
   - myst-nb>=0.12.0
   - netcdf4
-  - pip
   - pydata-sphinx-theme>=0.4.3
   - python-graphviz
-  - python=3.9
   - scipy
   - seaborn
   - sparse
@@ -32,5 +30,4 @@ dependencies:
   - sphinxext-rediraffe
   - sphinx-design
   - sphinx-copybutton
-  - pip:
-      - sphinxext-opengraph
+  - sphinxext-opengraph

--- a/environment.yml
+++ b/environment.yml
@@ -25,7 +25,7 @@ dependencies:
   - sphinx
   - sphinx-autobuild
   - sphinx-comments
-  - sphinxcontrib-bibtex<2.0.0
+  - sphinxcontrib-bibtex
   - xarray>=0.18.2
   - sphinxext-rediraffe
   - sphinx-design

--- a/index.md
+++ b/index.md
@@ -1,4 +1,4 @@
-# Earth System Data Science (ESDS) Initiative
+# Earth System Data Science
 
 Hello! This is a place to store updates from the ESDS working group
 including a variety of blog posts and resources for the community

--- a/office-hours.md
+++ b/office-hours.md
@@ -10,7 +10,7 @@ If your question is about an error message you are raising in your workflow, hel
 
 ```{admonition} ESDS Collaboratory on Wednesday, June 25!
 :class: admonition
-ESDS is organizing in-person "Collaboratory" days to encourage outreach, engagement, and the sharing of ideas between teams. These sessions will rotate through the ML, CG, and FL libraries (each lab housing one event per quarter). For more information, check out [this blog post](posts/2025/collaboratory.html).
+ESDS is organizing in-person "Collaboratory" days to encourage outreach, engagement, and the sharing of ideas between teams. These sessions will rotate through the ML, CG, and FL libraries (each lab housing one event per quarter). For more information, check out [this blog post](../posts/2025/collaborary).
 ```
 
 <iframe


### PR DESCRIPTION
This PR does the following:
* Adds an ESDS favicon for the website
* Reverts back to the ESDS overview lefthand sidebar
* Edits the top navbar to be a bit more concise
* Cleans up the environment file a bit and removes unnecessary pins
* Updates the theme configuration to cut down on warnings from various deprecations and generally clean up formatting a bit
* Updates a few links so they work and don't throw MyST warnings

I had considered breaking the content up into sections and leveraging the lefthand menu for section navigation [as is done by default for the theme](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/layout.html), but I opted to skip that for now since I think we'd need a little more content to make that worthwhile.

We could still use to update some of the remaining content and it may be worth considering moving the source material to a docs folder so that the repo is a bit less cluttered and we're not including things unintentionally in the build, but those can be items for later.  