### PR TITLE
June 2026 updates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,11 +16,11 @@ jobs:
       run:
         shell: bash -l {0}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Install dependencies
       - name: Setup Conda Environment
-        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 #v4.0.1
+        uses: conda-incubator/setup-miniconda@8ee1f361103df19b6f8c8655fd3967a8ecb162d5 # v4.0.1
         with:
           environment-file: environment.yml
           activate-environment: esds-blog
@@ -31,7 +31,7 @@ jobs:
           make dirhtml
       # Push the book's HTML to github-pages
       - name: GitHub Pages action
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 #v4.1.0
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/about.md
+++ b/about.md
@@ -12,11 +12,8 @@ described in our [governance document](https://docs.google.com/document/d/1xjNzJ
 ## ESDS Representatives
 
 * Drew Camron, Unidata
-* John Clyne, CISL
 * Katelyn FitzGerald, CISL
 * Rubaiat Islam, MMM
-* Julia Kent, CISL
-* Teagan King, CGD
 * Mike Levy, CGD
 * Ryan May, Unidata
 * Susan Stringer, EOL

--- a/communication.md
+++ b/communication.md
@@ -2,7 +2,7 @@
 
 ## Email List
 
-If you would like to join the ESDS email list to be informed of community updates, we recommend you do so by joining the ESDS Google Group by clicking the button below, then click "Join Group."
+If you would like to join the ESDS email list to be informed of community updates, you can do so by joining the ESDS Google Group. While logged in to your preferred Google account, click the button below and request to join the group.
 
 <a href="https://groups.google.com/a/ucar.edu/g/esds" target="_blank">
   <button style="
@@ -25,7 +25,7 @@ If you would like to join the ESDS email list to be informed of community update
 
 ## Slack
 
-Slack is an asynchronous messaging platform which can be used for both private messages and messages within channels.
+You can also find us on the NCAR Compute and Data Commons (NCDC) Slack workspace. Follow the link below to join.
 
 <a href="https://join.slack.com/t/ncarhpcusergroup/shared_invite/zt-3427n89dh-27_tGO3k6QiPCluMqzF0jA" target="_blank">
   <button style="
@@ -49,14 +49,14 @@ Slack is an asynchronous messaging platform which can be used for both private m
 
 ## ESDS Forum
 
-The first Tuesday of every month from 1-2pm MT, we hold the ESDS Forum over [Google Meet](https://meet.google.com/mfb-whpi-tnj), which provides a venue for discussion, coordination and showcasing work in progress. Examples include:
+The first Tuesday of every month from 1-2pm MT, we hold the ESDS Forum over [Google Meet](https://meet.google.com/mfb-whpi-tnj). This recurring event provides a venue for discussion, coordination, and showcasing relevant work. Examples include:
 
 - Workflow demos
 - Overview of packages and analysis tools
 - Focused discussions on new efforts
 - Feedback on computing and analysis resources
 
-This is a great place to discuss progress on your project, and get feedback from the community!
+This is a great place to share work in progress, and get feedback from the community!
 
 <a href="https://docs.google.com/document/d/e/2PACX-1vQeHIGSSz_8A8gZVL87xDjYXEwqB4CkRk85yf0TACb-rVgubjb3ukiulEYuUwHZGVXhgYNpaRC2SNAt/pub" target="_blank">
   <button style="

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
-  - python>=3.7
+  - python
   - pip
   - ablog
   - cftime
@@ -13,20 +13,20 @@ dependencies:
   - distributed
   - graphviz
   - ipywidgets
-  - jupyterlab>=3
+  - jupyterlab
   - matplotlib
-  - myst-nb>=0.12.0
+  - myst-nb
   - netcdf4
-  - pydata-sphinx-theme>=0.4.3
+  - pydata-sphinx-theme
   - python-graphviz
   - scipy
   - seaborn
   - sparse
-  - sphinx<9
+  - sphinx
   - sphinx-autobuild
   - sphinx-comments
   - sphinxcontrib-bibtex
-  - xarray>=0.18.2
+  - xarray
   - sphinxext-rediraffe
   - sphinx-design
   - sphinx-copybutton

--- a/office-hours.md
+++ b/office-hours.md
@@ -8,11 +8,6 @@ If your question is about an error message you are raising in your workflow, hel
 
 **NOTE:** Office hours are designed for NSF NCAR and UCAR staff.
 
-```{admonition} ESDS Collaboratory on Wednesday, November 19th!
-:class: admonition
-ESDS is organizing in-person "Collaboratory" days to encourage outreach, engagement, and the sharing of ideas between teams. These sessions will rotate between the Mesa Lab and Foothills Lab. For more information, check out [this blog post](../posts/2025/collaboratory_november).
-```
-
 <iframe
   src="https://app.squarespacescheduling.com/schedule.php?owner=26907589"
   title="Schedule Appointment"


### PR DESCRIPTION
Miscellaneous updates:
* Removes version pins we no longer need (either very dated or issues addressed upstream)
* Updates the list of representatives
* Remove old collaboratory announcement
* Minor updates to website language for clarity